### PR TITLE
Change URL to Nominatim API

### DIFF
--- a/js/Control.NominatimGeocoder.js
+++ b/js/Control.NominatimGeocoder.js
@@ -78,7 +78,7 @@ L.Control.NominatimGeocoder = L.Control.extend({
 			limit: 1,
 			json_callback : this._callbackId
 		},
-		url =  "http://open.mapquestapi.com/nominatim/v1/search" + L.Util.getParamString(params),
+		url =  "https://nominatim.openstreetmap.org/search" + L.Util.getParamString(params),
 		script = document.createElement("script");
 
 		script.type = "text/javascript";


### PR DESCRIPTION
We switch from MapQuest Nominatim to the one
provided by OSM. The reason is MapQuest needs
API key and OSM limits are sufficient for now.