### PR TITLE
Make loading config more obvious

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-config.php
+config.local.php

--- a/README.md
+++ b/README.md
@@ -14,3 +14,9 @@ Stop:
 ```
 docker-compose down
 ```
+
+# Configuration
+
+Configuration is stored inside `config.php` file. Please see this file for all the details.
+
+All secret information (like passwords) should be kept inside `config.local.php` (example: `config.local.example.php`) which will never be stored inside VCS repository.

--- a/config.local.example.php
+++ b/config.local.example.php
@@ -1,0 +1,4 @@
+<?php
+define('USERNAME', 'username-on-osm');
+define('PASSWORD', 'password-on-osm');
+?>

--- a/config.php
+++ b/config.php
@@ -1,0 +1,14 @@
+<?php
+
+// Credentials to OpenStreetMap account for OSM24
+define('USERNAME', '');
+define('PASSWORD', '');
+
+/**
+ * Include a local settings file if it exists. This is the right place to keep secret informations.
+ */
+$local_settings = dirname(__FILE__) . '/config.local.php';
+if (file_exists($local_settings)) {
+  include $local_settings;
+}
+?>

--- a/js/main.js
+++ b/js/main.js
@@ -124,7 +124,7 @@ function showNoteMessage(header,body,callback,lon,lat){
 
 function add(lonv,latv,name){
   $.ajax({
-    url: "http://osm24.eu/add_note.php",
+    url: "add_note.php",
     data: {lon:lonv,lat:latv,text:"("+name+") "+$( "#text1").val()},
     success: function(data){$msg2Modal.modal('hide')},
   });


### PR DESCRIPTION
We have one "main" config file and a file with
secret config variables.
Also fixed URL to "add note" endpoint.